### PR TITLE
Removed new_relic for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,10 @@ gem 'uglifier', '~> 1.2.0'
 gem 'haml', '~> 3.1.4'
 gem 'redcarpet', '~> 2.1.0'
 
-# Monitoring
-gem 'newrelic_rpm', '~> 3.4.0'
+group :production do
+  # Monitoring
+  gem 'newrelic_rpm', '~> 3.4.0' #Only needed in production
+end
 
 # Date Handling
 gem 'ice_cube', "~> 0.8.0"


### PR DESCRIPTION
Bei mir hat das New_Relic ohne Config beim starten ne Menge overhead verursacht ... Ich habs mal in ne extra group gepackt, weils ja eigentlich nur in Prod gebraucht wird, oder? Habs mal im extra Branch gemacht, wenns so nicht funktioniert, dann einfach canceln ;)
