### PR TITLE
Omniauth

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,8 +1,10 @@
 class CallbacksController < Devise::OmniauthCallbacksController
-  def twitter
+  
+  # One method to serve them all!
+  def all
     user = User.from_omniauth(request.env["omniauth.auth"])
     if user.persisted?
-      flash.notice = "Eingeloggt via Twitter"
+      flash.notice = "Signed in via #{request.env["omniauth.auth"]["provider"].capitalize}"
       sign_in_and_redirect user
     else
       session["devise.user_attributes"] = user.attributes
@@ -10,16 +12,9 @@ class CallbacksController < Devise::OmniauthCallbacksController
     end
   end
   
-  def linkedin
-  end
-  
-  def facebook
-  end
-  
-  def google_oauth2
-  end
-  
-  def github
-  end
-  
+  alias_method :linkedin, :all
+  alias_method :twitter, :all
+  alias_method :facebook, :all
+  alias_method :google_oauth2, :all
+  alias_method :github, :all
 end

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -20,7 +20,7 @@
 	<li><%= link_to "Sign in with Google", user_omniauth_authorize_url(:google_oauth2) %></li>
 	<li><%= link_to "Sign in with GitHub", user_omniauth_authorize_url(:github) %></li>
 	<li><%= link_to "Sign in with Linkedin", user_omniauth_authorize_url(:linkedin) %></li>
-	<li><%= link_to "Sign in with Facebook", user_omniauth_authorize_url(:facebook) %></li>
+	<li>Sign in with Facebook</li>
 </ul>
 
 <%= render partial: "users/shared/links" %>

--- a/config/locales/devise.de.yml
+++ b/config/locales/devise.de.yml
@@ -1,43 +1,55 @@
 de:
   errors:
     messages:
-      not_found: "Nicht gefunden"
-      already_confirmed: "ist bereits bestätigt"
-      not_locked: "war nicht gesperrt"
+      expired: "ist abgelaufen, bitte neu anfordern"
+      not_found: "nicht gefunden"
+      already_confirmed: "wurde bereits bestätigt"
+      not_locked: "ist nicht gesperrt"
       not_saved:
-        one:    "Leider konnte das Konto nicht gespeichert werden."
-        other:  "Leider gab es %{count} Fehler bei dem Speichern des Kontos."
+        one: "Konnte %{resource} nicht speichern: ein Fehler."
+        other: "Konnte %{resource} nicht speichern: %{count} Fehler."
 
   devise:
     failure:
-      already_authenticated: "Du bist schon angemeldet."
-      unauthenticated: 'Du musst dich zuerst anmelden.'
-      unconfirmed: 'Du musst dein Konto zuerst bestätigen.'
-      locked: 'Dein Konto ist gesperrt.'
-      invalid: 'Falscher Benutzername oder falsches Passwort.'
-      invalid_token: 'Ungültiger Schlüssel.'
-      timeout: 'Die Sitzung ist abgelaufen, bitte melde dich erneut an.'
-      inactive: 'Dein Konto ist noch nicht aktiviert.'
+      already_authenticated: 'Du bist bereits angemeldet.'
+      unauthenticated: 'Du musst Dich anmelden oder registrieren, bevor Du fortfahren kannst.'
+      unconfirmed: 'Du musst Deinen Account bestätigen, bevor Du fortfahren kannst.'
+      locked: 'Dein Account ist gesperrt.'
+      invalid: 'Ungültige Anmeldedaten.'
+      invalid_token: 'Der Anmelde-Token ist ungültig.'
+      timeout: 'Deine Sitzung ist abgelaufen, bitte melde Dich erneut an.'
+      inactive: 'Dein Account ist nicht aktiv.'
     sessions:
       signed_in: 'Erfolgreich angemeldet.'
       signed_out: 'Erfolgreich abgemeldet.'
     passwords:
-      send_instructions: 'Du wirst in Kürze eine E-Mail erhalten, in der dir erklärt wird, wie du dein Passwort zurücksetzt.'
-      updated: 'Dein Passwort wurde erfolreich geändert. Du bist nun angemeldet.'
+      send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail mit der Anleitung, wie Du Dein Passwort zurücksetzen kannst.'
+      updated: 'Dein Passwort wurde geändert. Du bist jetzt angemeldet.'
+      updated_not_active: 'Dein Passwort wurde geändert.'
+      send_paranoid_instructions: "Falls Deine E-Mail-Adresse in unserer Datenbank existiert erhältst Du in wenigen Minuten eine E-Mail mit der Anleitung, wie Du Dein Passwort zurücksetzen können."
     confirmations:
-      send_instructions: 'Du wirst in Kürze eine E-Mail erhalten mit deren Hilfe du deinen Konto bestätigen kannst.'
-      confirmed: 'Dein Konto wurde erfolgreich bestätigt. Du bist nun angemeldet.'
+      send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail, mit der Du Deine Registrierung bestätigen kannst.'
+      send_paranoid_instructions: 'Falls Deine E-Mail-Adresse in unserer Datenbank existiert erhältst Du in wenigen Minuten eine E-Mail mit der Du Deine Registrierung bestätigen kannst.'
+      confirmed: 'Vielen Dank für Deine Registrierung. Du bist jetzt angemeldet.'
     registrations:
-      signed_up: 'Dein Konto wurde erfolgreich angelegt.'
-      updated: 'Dein Konto wurde aktualisiert.'
-      destroyed: 'Dein Konto wurde erfolgreich gelöscht.'
+      signed_up: 'Du hast dich erfolgreich registriert.'
+      signed_up_but_unconfirmed: 'Du hast Dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account noch nicht bestätigt ist. Du erhältst in Kürze eine E-Mail mit der Anleitung, wie Du Deinen Account freischalten kannst.'
+      signed_up_but_inactive: 'Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account inaktiv ist.'
+      signed_up_but_locked: 'Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account gesperrt ist.'
+      updated: 'Deine Daten wurden aktualisiert.'
+      update_needs_confirmation: "Deine Daten wurden aktualisiert, aber Du musst Deine neue E-Mail-Adresse bestätigen. Du erhälsts in wenigen Minuten eine E-Mail, mit der Du die Änderung Deiner E-Mail-Adresse abschließen kannst."
+      destroyed: 'Dein Account wurde gelöscht.'
     unlocks:
-      send_instructions: 'Du wirst in Kürze eine E-Mail mit den Anweisungen zum Entsperren des Kontos erhalten.'
-      unlocked: 'Dein Konto wurde erfolgreich entsperrt. Du bist nun angemeldet'
+      send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail mit der Anleitung, wie Du Deinen Account entsperren können.'
+      unlocked: 'Dein Account wurde entsperrt. Du bist jetzt angemeldet.'
+      send_paranoid_instructions: "Falls Deine E-Mail-Adresse in unserer Datenbank existiert erhältst Du in wenigen Minuten eine E-Mail mit der Anleitung, wie Du Deinen Account entsperren kannst."
+    omniauth_callbacks:
+      success: 'Du hast Dich erfolgreich mit Deinem %{kind}-Account angemeldet.'
+      failure: 'Du konntest nicht Deinem %{kind}-Account angemeldet werden, weil "%{reason}".'
     mailer:
       confirmation_instructions:
-        subject: 'Anweisungen zur Bestätigung'
+        subject: 'Anleitung zur Bestätigung Deines Accounts'
       reset_password_instructions:
-        subject: 'Anweisungen zur Passwortwiederherstellung'
+        subject: 'Anleitung um Dein Passwort zurückzusetzen'
       unlock_instructions:
-        subject: 'Anweisungen zum entsperren'
+        subject: 'Anleitung um Deinen Account freizuschalten'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -28,10 +28,11 @@ en:
       send_instructions: 'You will receive an email with instructions about how to reset your password in a few minutes.'
       updated: 'Your password was changed successfully. You are now signed in.'
       updated_not_active: 'Your password was changed successfully.'
-      send_paranoid_instructions: "If your e-mail exists on our database, you will receive a password recovery link on your e-mail"
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
     confirmations:
       send_instructions: 'You will receive an email with instructions about how to confirm your account in a few minutes.'
-      send_paranoid_instructions: 'If your e-mail exists on our database, you will receive an email with instructions about how to confirm your account in a few minutes.'
+      send_paranoid_instructions: 'If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes.'
       confirmed: 'Your account was successfully confirmed. You are now signed in.'
     registrations:
       signed_up: 'Welcome! You have signed up successfully.'
@@ -46,8 +47,8 @@ en:
       unlocked: 'Your account has been unlocked successfully. Please sign in to continue.'
       send_paranoid_instructions: 'If your account exists, you will receive an email with instructions about how to unlock it in a few minutes.'
     omniauth_callbacks:
-      success: 'Successfully authorized from %{kind} account.'
-      failure: 'Could not authorize you from %{kind} because "%{reason}".'
+      success: 'Successfully authenticated from %{kind} account.'
+      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
     mailer:
       confirmation_instructions:
         subject: 'Confirmation instructions'


### PR DESCRIPTION
I've added OmniAuth to the devise User Model so that we can create an account using different OAuth sites that might be relevant to nerds...
- Twitter
- Facebook
- GitHub
- LinkedIn
- Google

Currently, if one of the fields `nickname` or `email` is not provided by the service or if the email/nickname is already taken, we link the person to the signup page (ie Twitter gives nickname but no mail, Google gives mail but no nickname, etc...) but the user is not asked for a password ...

Additionally, a user can link more than one OAuth profile with his account so that we can use the information to post stuff to facebook, make tweets or (when Xing provides their API) make them attend events on other sites.

Any thoughts? Objections?

**This branch is not ready, don't merge it, I just added it to have a discussion**
