### PR TITLE
remove uploads from picture factory

### DIFF
--- a/test/factories/picture.rb
+++ b/test/factories/picture.rb
@@ -2,8 +2,6 @@ include ActionDispatch::TestProcess
 
 FactoryGirl.define do
   factory :picture do
-    carousel_image { fixture_file_upload(Rails.root.to_s + '/app/assets/images/test-werbung.png', "image/png") }
-    box_image { fixture_file_upload(Rails.root.to_s + '/app/assets/images/test-werbung.png', "image/png") }
     title "Some title"
   end
 end


### PR DESCRIPTION
Is the upload of the fixture file really necessary? The test runs without it!

And the important thing ist that the remove, speed up the tests from ~100sec to ~14sec!

@bitboxer, @moonglum, @klaustopher and @EinLama what is your opinion?
