### PR TITLE
remove IcalController#render_event and use #render_events for it

### DIFF
--- a/app/controllers/ical_controller.rb
+++ b/app/controllers/ical_controller.rb
@@ -27,7 +27,7 @@ class IcalController < ApplicationController
   end
 
   def for_single_event
-    render_event SingleEvent.find(params[:id])
+    render_events SingleEvent.find(params[:id])
   end
 
   def for_event
@@ -42,12 +42,6 @@ class IcalController < ApplicationController
 
   def set_calendar_headers
     response.headers["Content-Type"] = "text/calendar; charset=UTF-8"
-  end
-
-  def render_event(event)
-    ri_cal = RiCal.Calendar
-    ri_cal.events.push event.to_ri_cal_event(is_google_bot)
-    render text: ri_cal
   end
 
   def render_events(events)


### PR DESCRIPTION
`render_events` converts the event(s) to an array (this is needed to convert a ActiveModel-Query to a array of results), so we use it for events and event
