### PR TITLE
Don't "fix" empty homepage URLs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,7 +223,7 @@ class User < ActiveRecord::Base
     if github && m = github.match(/(?:http:\/\/)?github.com\/(.*)/)
       self.github = m[1]
     end
-    if homepage && !homepage.match(/\Ahttp(s)?:\/\//)
+    if homepage.present? && !homepage.match(/\Ahttp(s)?:\/\//)
       self.homepage = "http://#{homepage}"
     end
   end


### PR DESCRIPTION
Leaving the homepage field empty on the profile page causes `http://` to be saved instead.
