### PR TITLE
Export ALL the events in /export/ical

### DIFF
--- a/app/controllers/ical_controller.rb
+++ b/app/controllers/ical_controller.rb
@@ -35,6 +35,11 @@ class IcalController < ApplicationController
     render_events SingleEvent.only_tagged_with(params[:id]).in_region(current_region)
   end
 
+  def everything
+    # no kitchen sink though
+    render_events SingleEvent.recent_to_soon(3.months)
+  end
+
   private
 
   def set_calendar_headers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Hcking::Application.routes.draw do
   match "export/ical/attending/:guid"       => "ical#personalized"
   match "export/ical/event/:id"             => "ical#for_event"
   match "export/ical/single_event/:id"      => "ical#for_single_event", as: "single_event_ical"
+  match "export/ical"                       => "ical#everything"
 
   match "pages/:page_name"              => "pages#show"
 

--- a/spec/controllers/ical_controller_spec.rb
+++ b/spec/controllers/ical_controller_spec.rb
@@ -231,4 +231,21 @@ DESC
     @response.body.should_not include @vcal_event7
     @response.body.should include @vcal_event8
   end
+
+  it "should get ical calendar for everything" do
+    get :everything
+    expect(response.code).to eq("200")
+    @response.headers["Content-Type"].should == "text/calendar; charset=UTF-8"
+
+    @response.body.should start_with @vcal_start
+    @response.body.should end_with @vcal_end
+    @response.body.should include @vcal_event
+    @response.body.should include @vcal_event2
+    @response.body.should include @vcal_event3
+    @response.body.should include @vcal_event4
+    @response.body.should include @vcal_event5
+    @response.body.should include @vcal_event6
+    @response.body.should include @vcal_event7
+    @response.body.should include @vcal_event8
+  end
 end


### PR DESCRIPTION
So we can close #250. There's no link in the UI though, as I don't know any good place to put it.
