### PR TITLE
Fix specs #314

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -301,14 +301,16 @@ describe Event do
 
   it "should not find events for wrong region" do
     event = FactoryGirl.create(:simple)
-    region = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
+    region = Region.where(slug: "berlin")
+    region = FactoryGirl.create(:berlin_region) if region.empty?
     Event.in_region(region).count.should == 0
   end
 
   it "should find events that are in global region, no matter what region you give to it" do
     gevent = FactoryGirl.create(:global_single_event)
-    bregion = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
-    kregion = Region.where(slug: "koeln")  || FactoryGirl.create(:koeln_region)
+    bregion, kregion = Region.where(slug: "berlin"), Region.where(slug: "koeln")
+    bregion = FactoryGirl.create(:berlin_region) if bregion.empty?
+    kregion = FactoryGirl.create(:koeln_region) if kregion.empty?
 
     Event.in_region(bregion).count.should == 1
     Event.in_region(kregion).count.should == 1

--- a/spec/models/single_event_spec.rb
+++ b/spec/models/single_event_spec.rb
@@ -251,7 +251,8 @@ ical
   end
 
   it "should not find single events for wrong region" do
-    region = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
+    region = Region.where(slug: "berlin")
+    region = FactoryGirl.create(:berlin_region) if region.empty?
     SingleEvent.in_region(region).count.should == 0
   end
 
@@ -272,8 +273,9 @@ ical
 
   it "should find single events that are in global region, no matter what region you give to it" do
     gevent = FactoryGirl.create(:global_single_event)
-    bregion = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
-    kregion = Region.where(slug: "koeln")  || FactoryGirl.create(:koeln_region)
+    bregion, kregion = Region.where(slug: "berlin"), Region.where(slug: "koeln")
+    bregion = FactoryGirl.create(:berlin_region) if bregion.empty?
+    kregion = FactoryGirl.create(:koeln_region) if kregion.empty?
 
     SingleEvent.in_region(bregion).count.should == 1
     SingleEvent.in_region(kregion).count.should == 1


### PR DESCRIPTION
Note that this only fixes the symptoms.

I think what happens differently here than in 3.x is that `Region.where(slug: "foo")` returns a proxy object that will be for which the query will only be evaluated as necessary, as in the previous specs it wasn't necessary until `Event.in_region(region).count.should`, the `Region.where(slug: "berlin")` gets incorporated as a subquery, and Rails somehow doesn't generate that correctly (`SELECT COUNT(*) FROM "events"  WHERE (region_id = SELECT "regions".* FROM "regions"  WHERE "regions"."slug" = 'berlin' or region_id = 1)` vs. the correct `SELECT COUNT(*) FROM "events"  WHERE (region_id = (SELECT "regions".id FROM "regions"  WHERE "regions"."slug" = 'berlin') or region_id = 1)`, added are the braces and the `SELECT id` instead of `SELECT *`).

Furthermore, `Region.where(slug: "foo")` will always return the proxy object, whether the result set is empty or not, thus `Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)` will always return `Region.where(slug: "berlin")`.

Another problem I just noticed is that the spec passes an array of `Region`s although `Event.in_region` expects one region. This gave me an idea for another possible fix, I'll see about that.

This patch fixes the second problem, and indirectly the first. The first problem doesn't arise here because the query actually gets evaluated because of the `#empty?` call, and the `region` in `Event.in_region(region).count.should` is actually a list of `Region` objects. Furthermore, the third problem doesn't arise because region slugs should be unique.

All in all: this is a possible fix, but probably not the best one. I'll submit another one with point 3 taken care of :-)
