### PR TITLE
Fix specs #314

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -301,14 +301,14 @@ describe Event do
 
   it "should not find events for wrong region" do
     event = FactoryGirl.create(:simple)
-    region = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
+    region = Region.where(slug: "berlin").first || FactoryGirl.create(:berlin_region)
     Event.in_region(region).count.should == 0
   end
 
   it "should find events that are in global region, no matter what region you give to it" do
     gevent = FactoryGirl.create(:global_single_event)
-    bregion = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
-    kregion = Region.where(slug: "koeln")  || FactoryGirl.create(:koeln_region)
+    bregion = Region.where(slug: "berlin").first || FactoryGirl.create(:berlin_region)
+    kregion = Region.where(slug: "koeln").first  || FactoryGirl.create(:koeln_region)
 
     Event.in_region(bregion).count.should == 1
     Event.in_region(kregion).count.should == 1

--- a/spec/models/single_event_spec.rb
+++ b/spec/models/single_event_spec.rb
@@ -251,7 +251,7 @@ ical
   end
 
   it "should not find single events for wrong region" do
-    region = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
+    region = Region.where(slug: "berlin").first || FactoryGirl.create(:berlin_region)
     SingleEvent.in_region(region).count.should == 0
   end
 
@@ -272,8 +272,8 @@ ical
 
   it "should find single events that are in global region, no matter what region you give to it" do
     gevent = FactoryGirl.create(:global_single_event)
-    bregion = Region.where(slug: "berlin") || FactoryGirl.create(:berlin_region)
-    kregion = Region.where(slug: "koeln")  || FactoryGirl.create(:koeln_region)
+    bregion = Region.where(slug: "berlin").first || FactoryGirl.create(:berlin_region)
+    kregion = Region.where(slug: "koeln").first  || FactoryGirl.create(:koeln_region)
 
     SingleEvent.in_region(bregion).count.should == 1
     SingleEvent.in_region(kregion).count.should == 1


### PR DESCRIPTION
`Event.in_region` expects one `Region` as an argument whereas `Region.where(slug: "foo")` returns an array.

(Replaces #316)
