### PR TITLE
Localeapp: Don't require in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ gem 'feedjira', '~> 1.1.0'
 
 group :development do
   # Manage locales, see http://www.localeapp.com/projects/5442
-  gem 'localeapp'
+  gem 'localeapp', require: false
 
   # Deployment
   gem 'capistrano', '~> 2.13.0'

--- a/config/initializers/localeapp.rb
+++ b/config/initializers/localeapp.rb
@@ -1,5 +1,4 @@
-# If you don't have the localeapp api key, you can simple deactivate
-# localeapp and remove the complete code in this file :)
+# We only want to load localeapp if there is config file
 if Rails.env.development? && File.exist?("config/localeapp.yml")
   require 'localeapp/rails'
 
@@ -8,4 +7,9 @@ if Rails.env.development? && File.exist?("config/localeapp.yml")
   Localeapp.configure do |config|
     config.api_key = localeapp_config["key"]
   end
+end
+
+# In production there should be a config file ;)
+if Rails.env.production?
+  require 'localeapp/rails'
 end


### PR DESCRIPTION
This will ensure it will not break the development environment. The existing initializer already checked for an existing localeapp config and now you don't need to remove that code to work in dev mode.
