### PR TITLE
LocaleApp keeps throwing nil-pointers at me.

### DIFF
--- a/config/initializers/localeapp.rb
+++ b/config/initializers/localeapp.rb
@@ -1,6 +1,6 @@
 # If you don't have the localeapp api key, you can simple deactivate
 # localeapp and remove the complete code in this file :)
-if Rails.env.development? && File.exist?("config/localeapp.yml")
+if defined?(Rails) && Rails.env.development?
   require 'localeapp/rails'
 
   localeapp_config = YAML.load_file("config/localeapp.yml")


### PR DESCRIPTION
When running `rake db:reset` to test #362 I encountered 

```
vagrant@hacken:/opt/hacken.in$ VERBOSE=true bundle exec rake setup:admin --trace
vagrant@hacken:/opt/hacken.in$ VERBOSE=true bundle exec rake setup:admin --trace
** Invoke setup:admin (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute setup:admin
Username:
a
Password:
a
Emailaddress:
a
rake aborted!
undefined method `add' for nil:NilClass
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/localeapp-0.7.1/lib/localeapp/default_value_handler.rb:12:in `default'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n/backend/base.rb:34:in `translate'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n.rb:157:in `block in translate'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n.rb:153:in `catch'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/i18n-0.6.9/lib/i18n.rb:153:in `translate'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:374:in `full_message'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:350:in `block in full_messages'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:162:in `block (2 levels) in each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:162:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:162:in `block in each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:161:in `each_key'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:161:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:350:in `map'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activemodel-4.0.4/lib/active_model/errors.rb:350:in `full_messages'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/validations.rb:16:in `initialize'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/validations.rb:57:in `new'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/validations.rb:57:in `save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/attribute_methods/dirty.rb:41:in `save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:275:in `block in save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:330:in `block in with_transaction_returning_status'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/connection_adapters/abstract/database_statements.rb:221:in `within_new_transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:209:in `transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:327:in `with_transaction_returning_status'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:275:in `save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/validations.rb:41:in `create!'
/opt/hacken.in/lib/tasks/setup.rake:27:in `block (2 levels) in <top (required)>'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:236:in `call'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:236:in `block in execute'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:231:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:231:in `execute'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:175:in `block in invoke_with_call_chain'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:168:in `invoke_with_call_chain'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:161:in `invoke'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:149:in `invoke_task'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `block in top_level'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:115:in `run_with_threads'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:100:in `top_level'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:78:in `block in run'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:165:in `standard_exception_handling'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:75:in `run'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/bin/rake:33:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.0.0-p353/bin/rake:23:in `load'
/home/vagrant/.rbenv/versions/2.0.0-p353/bin/rake:23:in `<main>'
Tasks: TOP => setup:admin
```

as soon as I disable localeapp (by commenting it out in the Gemfile - am I right?), the correct error message pops up:

```
vagrant@hacken:/opt/hacken.in$ VERBOSE=true bundle exec rake setup:admin --trace
** Invoke setup:admin (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute setup:admin
Username:
a
Password:
a
Emailaddress:
a
rake aborted!
Gültigkeitsprüfung ist fehlgeschlagen: E-Mailadresse ist nicht gültig, Passwort ist zu kurz (nicht weniger als 6 Zeichen)
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/validations.rb:57:in `save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/attribute_methods/dirty.rb:41:in `save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:275:in `block in save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:330:in `block in with_transaction_returning_status'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/connection_adapters/abstract/database_statements.rb:221:in `within_new_transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:209:in `transaction'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:327:in `with_transaction_returning_status'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/transactions.rb:275:in `save!'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/activerecord-4.0.4/lib/active_record/validations.rb:41:in `create!'
/opt/hacken.in/lib/tasks/setup.rake:27:in `block (2 levels) in <top (required)>'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:236:in `call'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:236:in `block in execute'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:231:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:231:in `execute'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:175:in `block in invoke_with_call_chain'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:168:in `invoke_with_call_chain'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/task.rb:161:in `invoke'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:149:in `invoke_task'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:106:in `block in top_level'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:115:in `run_with_threads'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:100:in `top_level'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:78:in `block in run'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:165:in `standard_exception_handling'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/lib/rake/application.rb:75:in `run'
/home/vagrant/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rake-10.1.1/bin/rake:33:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.0.0-p353/bin/rake:23:in `load'
/home/vagrant/.rbenv/versions/2.0.0-p353/bin/rake:23:in `<main>'
Tasks: TOP => setup:admin
```
