### PR TITLE
Add Warning banner to master.hacken.in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,6 +61,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :get_ical_link_for
 
+  def staging_users_should_be_warned
+    session[:region].nil? && request.host == 'master.hacken.in'
+  end
+  helper_method :staging_users_should_be_warned
+
   protected
 
   def configure_permitted_parameters

--- a/app/views/modules/common/_topbar.html.haml
+++ b/app/views/modules/common/_topbar.html.haml
@@ -1,4 +1,9 @@
 %header.contain-to-grid
+  - if staging_users_should_be_warned
+    .alert-box.alert.text-center
+      %h3
+        = raw t('modules.common.topbar.test_environment_warning')
+        %a.close{href: "#"}×
   %nav.top-bar{ data: { topbar: true } }
 
     %ul.left

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -431,6 +431,7 @@ de:
         search_form:
           field_placeholder: Finde Events
           button: Suchen
+        test_environment_warning: Achtung, das ist unsere Test-Umgebung. Richtige Events gibt es auf <a href="http://www.hacken.in">hacken.in!</a>.
       sidebar:
         login_with: "%{provider} login"
         register_instead: Registrieren

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,3 +428,4 @@ en:
       topbar:
         search_form:
           button: 
+        test_environment_warning: Caution, this is our sandbox environment. For real events check <a href="http://www.hacken.in">hacken.in!</a>.

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe WelcomeController, type: :controller do
   include Devise::TestHelpers
-
   context "index" do
     it "should redirect to /deutschland if no region is set in session" do
       get :index
@@ -29,4 +28,19 @@ describe WelcomeController, type: :controller do
       expect(response).to redirect_to "/deutschland"
     end
   end
+
+  context "warn" do
+    render_views
+    it "should warn users visiting a staging app" do
+      @request.host = 'master.hacken.in'
+      FactoryGirl.create(:koeln_region)
+      get 'deutschland'
+      expect(response.body).to match(/Achtung, das ist unsere Test-Umgebung/)
+      get :move_to, region: "koeln"
+      @request.host = 'master.hacken.in'
+      get 'deutschland'
+      expect(response.body).to_not match(/Achtung, das ist unsere Test-Umgebung/)
+    end
+  end
+
 end


### PR DESCRIPTION
I like the idea of having a transparent staging environment, where everyone can see our progress. Nevertheless we should add a (top?) banner to the staging site at master.hacken.in to keep people from registering or entering new events.
