### PR TITLE
Allow Robots to crawl hacken.in again (fixes #390)

### DIFF
--- a/config/deploy/shelly/before_restart
+++ b/config/deploy/shelly/before_restart
@@ -5,3 +5,5 @@ set -e
 mkdir -p disk/uploads
 ln -s ../disk/uploads public/uploads
 
+# Copy appropriate robots.txt
+cp "app/current/public/robots-$CLOUD_NAME.txt" "app/current/public/robots.txt"

--- a/public/robots-hacken-in-master.txt
+++ b/public/robots-hacken-in-master.txt
@@ -1,0 +1,4 @@
+# Ohai, fellow robots. Pls dont crawl our staging env. kthxbai?
+# (This file was copied from robots-hacken-in-master.txt by our deploy hook)
+User-Agent: *
+Disallow: /

--- a/public/robots-hacken-in.txt
+++ b/public/robots-hacken-in.txt
@@ -1,0 +1,2 @@
+# Ohai, fellow robots. Nothing to see here.
+# (This file was copied from robots-hacken-in.txt by our deploy hook)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-User-Agent: *
-Disallow: /


### PR DESCRIPTION
- Allow Robots to crawl our live site
- Disallow Robots to crawl our master site
- Copy the correct file (via CLOUD_NAME) to our web dir
