### PR TITLE
Fix deploy hook for robots.txt

### DIFF
--- a/config/deploy/shelly/before_restart
+++ b/config/deploy/shelly/before_restart
@@ -6,4 +6,4 @@ mkdir -p disk/uploads
 ln -s ../disk/uploads public/uploads
 
 # Copy appropriate robots.txt
-cp "app/current/public/robots-$CLOUD_NAME.txt" "app/current/public/robots.txt"
+cp "public/robots-$CLOUD_NAME.txt" "public/robots.txt"


### PR DESCRIPTION
Hooks are executed with PWD inside of the app folder.
