### PR TITLE
GitHub will fail if we only supply a host (fixes #522)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,9 +63,9 @@ Hcking::Application.configure do
   config.active_support.deprecation = :notify
 
   # Explicitly set the hostname to pick up the ENV['HTTP_HOST']
-  # provided by Shellycloud. We default to our production hostname.
+  # provided by Shellycloud. Don't ask, don't tell. *sobs*
   OmniAuth.config.full_host = lambda do |environment|
-    environment['HTTP_HOST'] || 'hacken.in'
+    "https://#{environment['HTTP_HOST']}"
   end
 
   # Shut up noisy rails logs


### PR DESCRIPTION
Apparently in rails jargon `full_host` can be any of host name, scheme
or even port number, so we have to be explicit and bite our tongue.