### PR TITLE
Update token emails to comply with Devise 3.x (fixes #489)

### DIFF
--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -2,6 +2,6 @@
 
 <p>Du musst jetzt nur noch deine E-Mail-Adresse bestätigen, in dem du diesen Link klickst:</p>
 
-<p><%= link_to 'E-Mail-Adresse bestätigen', confirmation_url(@resource, confirmation_token: @resource.confirmation_token) %></p>
+<p><%= link_to 'E-Mail-Adresse bestätigen', confirmation_url(@resource, confirmation_token: @token) %></p>
 
 <p>Danke!</p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,5 @@
 <p>Hallo <%= @resource.email %>!</p>
 
-<p>Jemand hat verlangt, das Passwort für dein Konto zu ändern. Wenn du dies angefordert hast, kannst du das Passwort über <%= link_to 'diesen Link', edit_password_url(@resource, reset_password_token: @resource.reset_password_token) %> tun.</p>
+<p>Jemand hat verlangt, das Passwort für dein Konto zu ändern. Wenn du dies angefordert hast, kannst du das Passwort über <%= link_to 'diesen Link', edit_password_url(@resource, reset_password_token: @token) %> tun.</p>
 
 <p>Wenn du das Passwort nicht ändern willst, kannst du diese EMail ignorieren.</p>


### PR DESCRIPTION
See http://blog.plataformatec.com.br/2013/08/devise-3-1-now-with-more-secure-defaults/ for more details.
Given that we updated to Devise 3 over 1 year ago, this has been broken since 8cd6fe26. :speak_no_evil: 

On a second thought: hacken.in users seem to like OAuth. :dancers: 