### PR TITLE
Adding a sleep to throttle the api requests, hopefully fixes #567

### DIFF
--- a/lib/radar/meetup.rb
+++ b/lib/radar/meetup.rb
@@ -4,6 +4,7 @@ module Radar
   class Meetup < Base
 
     def next_events
+      sleep(2) unless Rails.env.test?
       json = JSON.parse(RubyMeetup::ApiKeyClient.new.get_path("/2/events", {group_urlname: group_urlname}))
       json["results"].map do |event|
         cleanup_event(event)


### PR DESCRIPTION
This is just a first try to fix the api throtteling. If this is not working, we need to find a smarter way to do this.