### PR TITLE
Added sleep to twitter api calls and exception message

### DIFF
--- a/lib/twitter_follower.rb
+++ b/lib/twitter_follower.rb
@@ -9,9 +9,10 @@ class TwitterFollower
     not_followed_handles.each do |handle|
       puts "Following #{handle}" unless Rails.env.test?
       begin
+        sleep 0.5
         @client.follow(handle)
       rescue => e
-        Bugsnag.notify "Problems following #{handle}"
+        Bugsnag.notify "Problems following #{handle} #{e.message}"
       end
     end
   end

--- a/lib/twitter_list_updater.rb
+++ b/lib/twitter_list_updater.rb
@@ -19,10 +19,11 @@ class TwitterListUpdater
     (handles - handles_in_list).each do |screen_name|
       begin
         request_wrapper do
+          sleep 0.5
           @client.add_list_member(list, screen_name) unless screen_name == "hacken_in"
         end
       rescue => e
-        Bugsnag.notify "Problems following #{screen_name}"
+        Bugsnag.notify "Problems following #{screen_name} #{e.message}"
       end
     end
   end


### PR DESCRIPTION
This is needed because twitter rate limits the api. We need
to add this slowly.