### PR TITLE
Fix Seeds.rb: Reset PK Sequence after adding data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,3 +88,8 @@ Tagging.create!([
   {tag_id: 3, taggable_id: 2, taggable_type: "Event", tagger_id: nil, tagger_type: nil, context: "tags"},
   {tag_id: 5, taggable_id: 2, taggable_type: "Event", tagger_id: nil, tagger_type: nil, context: "tags"},
 ])
+
+# Reset the Primary Key Sequence as the IDs are created manually for some of the seeds
+ActiveRecord::Base.connection.tables.each do |table|
+  ActiveRecord::Base.connection.reset_pk_sequence!(table)
+end


### PR DESCRIPTION
This fixes a bug where you could not add any events after using `rake db:seed` as you would run into a uniqueness constraint on the primary key.

This was due to our seeds data setting the primary key by hand which does not influence the primary key sequence.

As we need to set the keys manually (because we use the keys as foreign keys again in other data sets), we need to reset the primary key sequence for all tables.