### PR TITLE
Don't be too optimistic about user supplied URLs (refs #588)

### DIFF
--- a/lib/radar/meetup.rb
+++ b/lib/radar/meetup.rb
@@ -1,4 +1,5 @@
 require 'ruby_meetup'
+require 'addressable/uri'
 
 module Radar
   class Meetup < Base
@@ -11,8 +12,14 @@ module Radar
       end
     end
 
+    # Optimistic group name parser for meetup.com.
+    # Will for example extract 'Git-Aficionados'
+    # from http://www.meetup.com/Git-Aficionados/events/155514542/
+    # As @radar_setting.url is user input we shouldn't be too naive.
     def group_urlname
-      @radar_setting.url.match(/http(?:s?):\/\/www.meetup.com\/([^\/]*)/)[1]
+      url = Addressable::URI.heuristic_parse(@radar_setting.url)
+      parts = url.path.split('/')
+      parts.second || ''
     end
 
     def cleanup_event(event)

--- a/spec/lib/radar/meetup_spec.rb
+++ b/spec/lib/radar/meetup_spec.rb
@@ -125,6 +125,16 @@ describe Radar::Meetup do
     expect(Radar::Meetup.new(setting).group_urlname).to eq("Git-Aficionados")
   end
 
+  it "should get clean up b0rken urls" do
+    meetup = Radar::Meetup.new(RadarSetting.create(url: "www.meetup.com/Git-Aficionados/events/155514542/"))
+    expect(meetup.group_urlname).to eq("Git-Aficionados")
+  end
+
+  it "should fail gracefully when there is no URL to match" do
+    meetup = Radar::Meetup.new(RadarSetting.create(url: "lol sorry, but I haven't read the RFC"))
+    expect(meetup.group_urlname).to eq('')
+  end
+
   it "should get a time offset string from time in milliseconds" do
     meetup = Radar::Meetup.new(setting)
     expect(meetup.get_offset(3600000)).to eq("+01:00")


### PR DESCRIPTION
* Switch to addressable/uri's heuristic parser to get the most out of
  the user supplied URLs in our meeting radar
* At least bail out with an empty group name instead of niling all over
  the place. :-)