### PR TITLE
Cast event_ids to String to make them compatible PostgreSQL

### DIFF
--- a/lib/radar/base.rb
+++ b/lib/radar/base.rb
@@ -39,7 +39,9 @@ module Radar
     end
 
     def mark_missing(start_time, event_ids)
-      @radar_setting.entries.where("entry_date > ? and entry_id not in (?)", start_time, event_ids).each do |entry|
+      # Cast event_ids to string because they are stored as type varchar
+      # PostgreSQL will refuse to compare character varying <> integer
+      @radar_setting.entries.where("entry_date > ? and entry_id not in (?)", start_time, event_ids.map(&:to_s)).each do |entry|
         if entry.entry_type != "MISSING"
           entry.entry_type = "MISSING"
           entry.content = {}

--- a/spec/lib/radar_base_spec.rb
+++ b/spec/lib/radar_base_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Radar::Base do
+  let(:radar) {
+    Radar::Base.new(RadarSetting.create())
+  }
+
+  it "should handle postgres type casts (GitHub issue #591)" do
+    expect{ radar.mark_missing(nil, [1,2,3]) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
* entry_id is matched with IN () but PostgreSQL tries to compare Integer
  with character varying triggering a PG::UndefinedFunction

Full stack trace from Bugsnag:
```
PG::UndefinedFunctionERROR: operator does not exist: character varying <> integer LINE 1:
 ..._date > '2015-04-23 16:44:38.159208' and entry_id not in (27... 
                                                                                       ^ 
HINT: No operator matches the given name and argument type(s). 
You might need to add explicit type casts. 
```