### PR TITLE
Add haml+i18n for password reset (fixes #486)

### DIFF
--- a/app/views/users/passwords/edit.html.haml
+++ b/app/views/users/passwords/edit.html.haml
@@ -1,0 +1,13 @@
+%h2
+  = t('sessions.edit.title')
+
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = devise_error_messages!
+  = f.hidden_field :reset_password_token
+  %div
+    = f.label :password, t('sessions.edit.password')
+    = f.password_field :password, autofocus: true, autocomplete: "off"
+  %div
+    = f.label :password_confirmation, t('sessions.edit.password_confirmation')
+    = f.password_field :password_confirmation, autocomplete: "off"
+  %div= f.submit t('registrations.edit.save_profile'), class: :button

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -229,6 +229,10 @@ de:
       title: Einloggen
       with_other_service: "…oder mit einem dieser Services"
       with_user_data: Mit Benutzerdaten
+    edit:
+      title: Passwort ändern
+      password: Neues Passwort
+      password_confirmation: Neues Passwort (noch einmal, bitte)
   single_events:
     push:
       confirmation: Du nimmst jetzt teil.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,6 +229,10 @@ en:
       title: Login
       with_other_service: "…or with one of these services"
       with_user_data: With user data
+    edit:
+      title: Change password
+      password: New passwort
+      password_confirmation: Please repeat your new password
   single_events:
     show:
       participate: And me!


### PR DESCRIPTION
The `new` template was already there, so I suppose there was no
proper way to do this via *initializers* magic.