### PR TITLE
Display proper foundation errors for user model

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -7,4 +7,22 @@ module LayoutHelper
     content_for(:title) { h(page_title.to_s) }
     @show_title = show_title
   end
+
+  def display_error_messages!
+    return "" if resource.errors.empty?
+
+    messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+    sentence = I18n.t("errors.messages.not_saved",
+                      count: resource.errors.count,
+                      resource: resource.class.model_name.human.downcase)
+
+    html = <<-HTML
+    <div id="error_explanation" class="alert-box warning">
+      <p>#{sentence}</p>
+      <ul>#{messages}</ul>
+    </div>
+    HTML
+
+    html.html_safe
+  end
 end

--- a/app/views/users/passwords/edit.html.haml
+++ b/app/views/users/passwords/edit.html.haml
@@ -2,7 +2,7 @@
   = t('sessions.edit.title')
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-  = devise_error_messages!
+  = display_error_messages!
   = f.hidden_field :reset_password_token
   %div
     = f.label :password, t('sessions.edit.password')

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -74,7 +74,7 @@ ignore_missing:
 
 ## Consider these keys used
 ignore_unused:
-  - 'activerecord.attributes.*'
+  - 'activerecord.{attributes,errors}.*'
   - '{devise,kaminari,will_paginate}.*'
   - 'subscriptions.{push,delete}.confirmation'
   - 'single_events.{push,delete}.confirmation'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -82,12 +82,22 @@ de:
         password: Passwort
         password_confirmation: Passwort bestätigen
         twitter: Twitter Account
+        reset_password_token: Token zum Ändern des Passworts
       venue:
         city: Stadt
         country: Land
         location: Firma/Location
         street: Straße
         zipcode: PLZ
+    errors:
+      models:
+        user:
+          attributes:
+            reset_password_token:
+              invalid: |-
+                war ungültig. Bitte lass' Dir von uns ein neues
+                schicken und achte darauf dass Du es vollständig aus
+                der E-Mail kopierst.
   calendars:
     show:
       title: Kalender
@@ -279,3 +289,6 @@ de:
     show:
       headline: "Statistiken für %{region}"
       weekdays: "Wochentage"
+  errors:
+    messages:
+      not_saved: "Ups. Wir konnten das leider nicht speichern:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,12 +82,21 @@ en:
         password: Password
         password_confirmation: Confirm password
         twitter: Twitter
+        reset_password_token: Token for resetting your password
       venue:
         city: City
         country: Country
         location: Company/Location
         street: Street
         zipcode: Postal code
+    errors:
+      models:
+        user:
+          attributes:
+            reset_password_token:
+              invalid: |-
+                was invalid. Please try resetting your password again
+                and be sure to copy the whole link from your email.
   calendars:
     show:
       title: Calendar
@@ -230,7 +239,7 @@ en:
       with_other_service: "…or with one of these services"
       with_user_data: With user data
     edit:
-      title: Change password
+      title: Change 
       password: New passwort
       password_confirmation: Please repeat your new password
   single_events:
@@ -279,3 +288,6 @@ en:
     show:
       headline: "Statistics for %{region}"
       weekdays: "Weekdays"
+  errors:
+    messages:
+      not_saved: "Sorry. We couldn't save that:"


### PR DESCRIPTION
The foundation people [told me to copy this method](/plataformatec/devise/blob/master/app/helpers/devise_helper.rb#L6). So I copied this method.

And then I felt bad.

So I renamed the method for us to opt in.

Didn't feel better. So anyways. Merge pls?

Oh. Yeah. This fixes #547.
