### PR TITLE
Add Codeclimate config file (refs #586)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+languages:
+   Ruby: true
+   JavaScript: true
+exclude_paths:
+- "test/*"
+


### PR DESCRIPTION
See if this will bring back the code coverage reporting. We did all the
necessary steps and Codeship has the correct token.

[Codeclimate docs](http://docs.codeclimate.com/article/289-configuring-your-repository-via-codeclimate-yml)