### PR TITLE
Remove password from user form + add reset link

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -41,6 +41,9 @@ ActiveAdmin.register User do
     end
   end
 
+  action_item only: :edit do
+    link_to 'Send password reset email.', send_password_reset_link_admin_user_path(user.id), :method => :post
+  end
 
   controller do
     defaults finder: :find_by_nickname
@@ -56,8 +59,6 @@ ActiveAdmin.register User do
         :homepage,
         :team,
         :name,
-        :password,
-        :password_confirmation,
         {
           assigned_region_ids: [],
           curated_event_ids: []
@@ -66,4 +67,10 @@ ActiveAdmin.register User do
     end
   end
 
+  member_action :send_password_reset_link, method: :post do
+    user = User.find(params[:id])
+    user.send_reset_password_instructions
+    flash[:notice] = "Password reset instructions where sent to #{user.email}."
+    redirect_to edit_admin_user_path(user)
+  end
 end

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -4,8 +4,6 @@
     = f.input :name
     = f.input :email
     = f.input :description
-    = f.input :password
-    = f.input :password_confirmation
   = f.inputs "Kontakt" do
     = f.input :github
     = f.input :twitter


### PR DESCRIPTION
Remove all password fields from admin backend and provide the
possibility to send a password reset link from there. Should be
sufficient to support a user with a forgotten password. :)

fixes #582
