### PR TITLE
Don't Stop Me Now!

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,7 +16,10 @@ server "dubhe.uberspace.de", user: fetch(:user), roles: [:app, :db]
 namespace :deploy do
   task :restart do
     on roles(:app) do
-      execute "svc -h ~/service/hacken-in-#{fetch(:stage)}"
+      within release_path do
+        execute "kill -USR2 $(cat tmp/pids/unicorn.pid)"
+        execute "kill -WINCH $(cat tmp/pids/unicorn.pid.oldbin)"
+      end
     end
   end
 

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,50 @@
+#
+# Unicorn webserver config.
+# Large parts stolen from
+# https://github.com/tablexi/capistrano3-unicorn
+#
+
+# paths
+app_path = ENV["APP_PATH"]
+working_directory "#{app_path}/current"
+pid               "#{app_path}/current/tmp/pids/unicorn.pid"
+
+# logging
+stderr_path "log/unicorn.stderr.log"
+stdout_path "log/unicorn.stdout.log"
+
+# workers
+worker_processes 3
+
+# use correct Gemfile on restarts
+before_exec do |server|
+  ENV['BUNDLE_GEMFILE'] = "#{app_path}/current/Gemfile"
+end
+
+# preload
+preload_app true
+
+before_fork do |server, worker|
+  # the following is highly recomended for Rails + "preload_app true"
+  # as there's no need for the master process to hold a connection
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.connection.disconnect!
+  end
+
+  # Before forking, kill the master process that belongs to the .oldbin PID.
+  # This enables 0 downtime deploys.
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exists?(old_pid) && server.pid != old_pid
+    begin
+      Process.kill("QUIT", File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+      # someone else did our job for us
+    end
+  end
+end
+
+after_fork do |server, worker|
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.establish_connection
+  end
+end


### PR DESCRIPTION
I dug a bit around in the uberspace logs and came to realise that we're using daemontools wrong. Our old restart command was `svc -h` – which is actually quite nice if you are dealing with regular processes. Not such much with Unicorn, who is [quite opinionated](https://unicorn.bogomips.org/SIGNALS.html) about the signals. The `HUP` we sent left Unicorn in a unholy mess of an instance – still clung to the old release directory and a new Unicorn that couldn't bind to the port. 

We could use `svc -du` but that would mean a bit of a downtime during deployment, or we could use the built in handling of Unicorn (which will drain old and accept new connections so the site won't go down during deployment).

Long story short: Let's try to use `daemontools` only for the initial start of the webserver (say - after a system reboot) and let Unicorn take over from there. 

#### Changes:

* Let Uberspace do the initial start (on boot, that's about it)
* Let Unicorn handle USR2 + WINCH (restart, take over port + drain old master)

### Empirical proof that this will work flawlessly
```
INFO -- : worker=0 ready
INFO -- : worker=1 ready
INFO -- : master process ready
INFO -- : worker=2 ready
INFO -- : reaped #<Process::Status: pid 763 exit 0> worker=1
INFO -- : reaped #<Process::Status: pid 760 exit 0> worker=0
INFO -- : reaped #<Process::Status: pid 768 exit 0> worker=2
INFO -- : master complete
INFO -- : Refreshing Gem list
INFO -- : listening on addr=0.0.0.0:9944 fd=9
INFO -- : worker=0 ready
INFO -- : worker=1 ready
INFO -- : master process ready
INFO -- : worker=2 ready
INFO -- : gracefully stopping all workers
INFO -- : executing ["/home/hacken/hacken-in-master/shared/bundle/ruby/2.2.0/bin/unicorn", "-p", "9944", "-E", "production", "-c", "config/unicorn.rb", {9=>#<Kgio::TCPServer:fd 9>}] (in /home/hacken/hacken-in-master/releases/20160414212612)
INFO -- : reaped #<Process::Status: pid 19597 exit 0> worker=0
INFO -- : reaped #<Process::Status: pid 19603 exit 0> worker=2
INFO -- : reaped #<Process::Status: pid 19600 exit 0> worker=1
INFO -- : inherited addr=0.0.0.0:9944 fd=9
INFO -- : Refreshing Gem list
INFO -- : master complete
INFO -- : worker=0 ready
INFO -- : worker=1 ready
INFO -- : master process ready
INFO -- : worker=2 ready
```

### Actual depiction of Unicorn after receiving `USR2`

![Yaaasssssss](http://i.imgur.com/3zKCtx5.jpg)