### PR TITLE
Fix Event Page: Use the correct partial

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -27,7 +27,10 @@ ActiveAdmin.register Event do
     actions
   end
 
-  show partial: 'show'
+  show do
+    render partial: 'show'
+  end
+
   form partial: 'form'
 
   controller do


### PR DESCRIPTION
The event admin page does not show a link to all single events or the link to adding a new single events (that's super annoying btw. 😉). The reason is that the partial for showing the event admin page was not used. This PR fixes this. I'm not sure how this got broken, but I guess that was one of those ActiveAdmin updates 😉 